### PR TITLE
Create TravisCI API tests

### DIFF
--- a/src/clients/travis.js
+++ b/src/clients/travis.js
@@ -222,3 +222,49 @@ export function setEnvironmentVariable(travisAccessToken, repoId, environmentVar
       });
   });
 }
+
+/**
+ * Set environment variables on a Travis-CI project
+ *
+ * @param travisAccessToken
+ * @param username
+ * @param repositoryName
+ * @returns Promise (example shown below)
+ * {
+ *   "repo": {
+ *     "id": 82,
+ *     "slug": "sinatra/sinatra",
+ *     "description": "Classy web-development dressed in a DSL",
+ *     "last_build_id": 23436881,
+ *     "last_build_number": "792",
+ *     "last_build_state": "passed",
+ *     "last_build_duration": 2542,
+ *     "last_build_started_at": "2014-04-21T15:27:14Z",
+ *     "last_build_finished_at": "2014-04-21T15:40:04Z",
+ *     "active": "true"
+ *   }
+ * }
+ */
+export function fetchRepository(travisAccessToken, username, repositoryName) {
+  const repoSlug = `${username}/${repositoryName}`;
+  winston.debug('fetchRepository', repoSlug);
+
+  return new Promise((resolve, reject) => {
+    superagent
+      .get(`${travisApiUrl}/repos/${repoSlug}`)
+      .set({
+        'User-Agent': tyrAgent,
+        Accept: travisApiAccept,
+        Authorization: `token ${travisAccessToken}`
+      })
+      .end((err, res) => {
+        if (err) {
+          reject(err);
+        } else if (!res.body.repo) {
+          reject(new Error(`Unable to find the repository '${repoSlug}'!`));
+        } else {
+          resolve(res.body.repo);
+        }
+      });
+  });
+}

--- a/src/utils/travis.js
+++ b/src/utils/travis.js
@@ -77,18 +77,18 @@ export async function waitForSync(travisAccessToken, account) {
 /**
  * Initialize Travis-CI on the created project
  *
- * @param token
+ * @param githubToken
  * @param username
  * @param projectName
- * @param environmentVariables
- * @returns {Promise.<void>}
+ * @param envVariables
+ * @returns Promise: { travisAccessToken }
  */
-export async function enableTravisOnProject(token, username, projectName, environmentVariables) {
+export async function enableTravisOnProject(githubToken, username, projectName, envVariables) {
   winston.log('verbose', 'enabling travis for project');
 
   try {
     // Use the GitHub token to get a Travis token
-    const travisAccessToken = await travisClient.requestTravisToken(token);
+    const travisAccessToken = await travisClient.requestTravisToken(githubToken);
 
     // get the accounts for the user
     const response = await travisClient.getUserAccount(travisAccessToken);
@@ -99,7 +99,7 @@ export async function enableTravisOnProject(token, username, projectName, enviro
         account = response.accounts[i];
       }
 
-      // wait for the user's account to be done dsyncing....
+      // Wait for the user's account to be done syncing....
       await waitForSync(travisAccessToken, account);
 
       // Sync Travis with GitHub, which must be done before activating the repository
@@ -110,8 +110,8 @@ export async function enableTravisOnProject(token, username, projectName, enviro
       await travisClient.activateTravisHook(repoId, travisAccessToken);
 
       // Add environment variables
-      if (environmentVariables && environmentVariables.length !== 0) {
-        for (const env of environmentVariables) { // eslint-disable-line no-restricted-syntax
+      if (envVariables && envVariables.length !== 0) {
+        for (const env of envVariables) { // eslint-disable-line no-restricted-syntax
           await travisClient.setEnvironmentVariable( // eslint-disable-line no-await-in-loop
             travisAccessToken,
             repoId,
@@ -122,6 +122,7 @@ export async function enableTravisOnProject(token, username, projectName, enviro
     }
 
     winston.log('info', `TravisCI successfully enabled on ${username}/${projectName}`);
+    return travisAccessToken;
   } catch (err) {
     winston.log('error', `failed to enable TravisCI on ${username}/${projectName}`, JSON.stringify(err));
   }

--- a/test/github-travis-api-test.js
+++ b/test/github-travis-api-test.js
@@ -10,6 +10,12 @@ import {
   listUserRepositories,
   deleteRepository
 } from '../src/clients/github';
+import {
+  enableTravisOnProject
+} from '../src/utils/travis';
+import {
+  fetchRepository
+} from '../src/clients/travis';
 
 // You need to fill in these credentials before running the tests
 const credentialsFilename = 'github-test-credentials.txt';
@@ -151,4 +157,24 @@ describe('GitHub API:', function() {
     // Delete the new repository
     await deleteRepository(configs.projectName, configs.username, configs.password);
   });
+
+  it('Should be able to enable TravisCI on a GitHub repository', async function() {
+    // Lengthen the timeout, since it could take a while to sync Travis
+    this.timeout(60 * 1000);
+
+    // Create the repo
+    await createGitHubRepository(configs.projectName, configs.description, configs.token);
+
+    // Enable TravisCI on the new repository, and fetch info for assertion
+    const travisToken = await enableTravisOnProject(configs.token, configs.username, configs.projectName, null);
+    const repo = await fetchRepository(travisToken, configs.username, configs.projectName);
+
+    // Delete the repository
+    await deleteRepository(configs.projectName, configs.username, configs.password);
+
+    // Verify it was initialized
+    const expectedSlug = `${configs.username}/${configs.projectName}`;
+    assert.equal(repo.slug, expectedSlug);
+  });
+
 });


### PR DESCRIPTION
Closes #79 : Create test GitHub account, and create API tests

- Tests enabling Travis on a project with environment variables
- Adds some functionality for filtering errors returned by `superagent`.
