### PR TITLE
Command line argument for logging to file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,10 +87,3 @@ TYR_LOG_LEVEL=debug npm start
 # Instead, use 'verbose' to see more information
 TYR_LOG_LEVEL=verbose npm test
 ```
-
-If you want to save off the output from the console to a file, the `tee` command is
-very useful:
-
-```bash
-npm start | tee output.log
-```

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ tyr [OPTIONS]
 ```
 
 ### Options:
-* `-h, --help`       output usage information
-* `--config <file>`  configure project from configuration file
+* `-h, --help`       Output usage information
+* `--config <file>`  Configure project from configuration file
+* `--logfile <file>` The filepath that logs will be written to
 
 ## Configuration File
 ### Project Configurations

--- a/src/cli.js
+++ b/src/cli.js
@@ -6,7 +6,7 @@ import * as configFileReader from './utils/config-file-reader';
 import utils from './utils';
 import * as prompt from './prompt';
 import constants from './constants/constants';
-import { getActiveLogger } from './utils/winston';
+import { enableLogFile, getActiveLogger } from './utils/winston';
 
 const log = getActiveLogger();
 
@@ -222,6 +222,11 @@ async function signInToThirdPartyTools(configs) {
  *                For more information about commander: https://github.com/tj/commander.js
  */
 export default async function run(tyr) {
+  // Enable logging to file upon user request
+  if (tyr.logfile) {
+    enableLogFile(tyr.logfile);
+  }
+
   try {
     let configs = {};
     log.verbose('run');

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ function main(tyrProgram) {
 }
 
 program.usage('[options]')
-  .option('--config <file>', 'configure project from configuration file')
+  .option('--config <file>', 'Configure project from configuration file')
+  .option('--logfile <file>', 'The filepath that logs will be written to')
   .parse(process.argv);
 
 main(program);

--- a/src/utils/winston.js
+++ b/src/utils/winston.js
@@ -23,6 +23,12 @@ const customFormatting = format.printf((info) => {
   return `${level}${info.message}`;
 });
 
+// Formatting for writing to a log file includes the timestamp and level
+const logfileFormatting = format.printf((info) => {
+  const level = (`${info.level.toUpperCase()}       `).slice(0, 7);
+  return `${info.timestamp} [${level}] ${info.message}`;
+});
+
 /**
  * The info logger
  */
@@ -107,6 +113,9 @@ export function enableLogFile(logFilename) {
   getActiveLogger().add(new transports.File({
     level: 'debug',
     filename: logFilename,
-    format: customFormatting
+    format: format.combine(
+      format.timestamp(),
+      logfileFormatting
+    )
   }));
 }

--- a/test/winston-test.js
+++ b/test/winston-test.js
@@ -1,6 +1,7 @@
 import assert from 'assert';
+import fs from 'fs-extra';
 
-import { setActiveLogger, getActiveLogger } from '../src/utils/winston';
+import { enableLogFile, setActiveLogger, getActiveLogger } from '../src/utils/winston';
 import { beforeEach, afterEach } from 'mocha';
 
 // Test strategy for capturing console output found here:
@@ -28,12 +29,13 @@ function captureStream(stream){
 
 function logAllLevels(logger) {
   // NOTE: We can't capture stderr during mocha tests (which
-  // 'error' and 'debug' are written to)
-  // logger.error('error');
+  // 'error' and 'debug' are written to) unless they are
+  // logged to a file.
+  logger.error('error');
   logger.warn('warn');
   logger.info('info');
   logger.verbose('verbose');
-  // logger.debug('debug');
+  logger.debug('debug');
   logger.silly('silly');
 }
 
@@ -74,5 +76,31 @@ describe('Winston:', () => {
     // NOTE: 'debug' level is also written to stderr
     // See https://github.com/winstonjs/winston/pull/558
     assert.equal(hook.captured(), expected);
+  });
+
+  it('Should log to file if logging to file is enabled', (done) => {
+    const logFileName = 'tyr-test.log';
+    setActiveLogger('debug');
+    enableLogFile(logFileName);
+
+    // This happens in a tricky asynchronous way that can't be waited for,
+    // so we'll check the results in a timeout.
+    logAllLevels(getActiveLogger());
+
+    setTimeout(() => {
+      assert.equal(fs.existsSync(logFileName), true, `The log file '${logFileName}' does not exist!`);
+
+      const actualContents = fs.readFileSync(logFileName);
+      const containsLogs = (
+        actualContents.includes('[ERROR  ] error\n') &&
+        actualContents.includes('[WARN   ] warn\n') &&
+        actualContents.includes('[INFO   ] info\n') &&
+        actualContents.includes('[DEBUG  ] debug\n')
+      );
+      assert.ok(containsLogs, 'The contents of the log file don\'t match what\'s expected!');
+
+      fs.removeSync(logFileName);
+      done();
+    }, 1000);
   });
 });


### PR DESCRIPTION
Closes #100 : Command line argument for logging to file

Logs to file happen in the following format: `timestamp [LOGLEVEL] message`
