### PR TITLE
Fix 99 travis cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ notifications:
     on_success: never
 
 jobs:
+  allow_failures:
+    - stage: integration tests
   include:
-    - stage: unit tests
-      script: npm test
     - stage: integration tests
       script: npm run integrationTests
-      if: branch = dev AND type IS cron
+      if: (branch = dev) AND (type IS cron)

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ notifications:
     on_success: never
 
 jobs:
-  node_js:
-    - '6'
-    - '8'
   allow_failures:
     - stage: integration tests
   include:
     - stage: integration tests
+      node_js:
+        - '6'
+        - '8'
       script: npm run integrationTests
       if: (branch = dev) AND (type IS cron)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ node_js:
   - '6'
   - '8'
 
+cache:
+  directories:
+    - "node_modules"
+
 before_script:
   - npm run lint
 
@@ -12,3 +16,11 @@ after_success:
 notifications:
   email:
     on_success: never
+
+jobs:
+  include:
+    - stage: unit tests
+      script: npm test
+    - stage: integration tests
+      script: npm run integrationTests
+      if: branch = dev AND type IS cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ notifications:
     on_success: never
 
 jobs:
+  node_js:
+    - '6'
+    - '8'
   allow_failures:
     - stage: integration tests
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ jobs:
     - stage: integration tests
   include:
     - stage: integration tests
-      node_js:
-        - '6'
-        - '8'
+      node_js: '6'
+      node_js: '8'
       script: npm run integrationTests
       if: (branch = dev) AND (type IS cron)

--- a/test/integration/github-travis-api-test.js
+++ b/test/integration/github-travis-api-test.js
@@ -138,70 +138,69 @@ describe('GitHub API:', function() {
     assert.ok(configs.authUrl, 'The response should include a url!');
   });
 
-  it('Should be able to create and delete a new GitHub repository', async () => {
+  it('Should be able to create and delete a new GitHub repository', (done) => {
     // Create the repo
-    await createGitHubRepository(configs.projectName, configs.description, configs.token);
+    createGitHubRepository(configs.projectName, configs.description, configs.token).then(() => {
+      // List all repos fro the user account, and assert that the new repo is in the list
+      listUserRepositories(configs.token).then((repos) => {
+        const expectedFullName = `${configs.username}/${configs.projectName}`;
+        let isCreated = false;
+        repos.body.forEach((repo) => {
+          if (repo.full_name === expectedFullName) {
+            isCreated = true;
+          }
+        });
+        assert.equal(isCreated, true, 'The repository was not successfully created and/or listed!');
 
-    // List all repos fro the user account, and assert that the new repo is in the list
-    const repos = await listUserRepositories(configs.token);
-    const expectedFullName = `${configs.username}/${configs.projectName}`;
-    let isCreated = false;
-    repos.body.forEach((repo) => {
-      if (repo.full_name === expectedFullName) {
-        isCreated = true;
-      }
+        deleteRepository(configs.projectName, configs.username, configs.password).then(() => {
+          // The test is now complete
+          done();
+        });
+      })
     });
-    assert.equal(isCreated, true, 'The repository was not successfully created and/or listed!');
-
-    // Delete the new repository
-    await deleteRepository(configs.projectName, configs.username, configs.password);
   });
 
-  it('Should be able to enable TravisCI on a GitHub repository with environment variables', async function() {
+  it('Should be able to enable TravisCI on a GitHub repository with environment variables', function(done) {
     // Lengthen the timeout, since it could take a while to sync Travis
     this.timeout(120 * 1000);
 
     // Create the repo
-    await createGitHubRepository(configs.projectName, configs.description, configs.token);
+    createGitHubRepository(configs.projectName, configs.description, configs.token).then(() => {
+      // Enable TravisCI on the new repository, and fetch info for assertion
+      const environmentVariables = [
+        {
+          name: 'MEANING_OF_LIFE',
+          value: '42'
+        },
+        {
+          name: 'HOLMGANG',
+          value: 'A Viking trial-by-combat',
+          public: true
+        }
+      ];
 
-    // Enable TravisCI on the new repository, and fetch info for assertion
-    const environmentVariables = [
-      {
-        name: 'MEANING_OF_LIFE',
-        value: '42'
-      },
-      {
-        name: 'HOLMGANG',
-        value: 'A Viking trial-by-combat',
-        public: true
-      }
-    ];
-    let travisToken, repo, envVarsRetrieved;
-    try {
-      travisToken = await enableTravisOnProject(
-        configs.token,
-        configs.username,
-        configs.projectName,
-        environmentVariables
-      );
-      repo = await fetchRepository(travisToken, configs.username, configs.projectName);
-      envVarsRetrieved = await listEnvironmentVariables(travisToken, repo.id);
-    } finally {
-      // Delete the repository
-      await deleteRepository(configs.projectName, configs.username, configs.password);
-    }
+      enableTravisOnProject(configs.token, configs.username, configs.projectName, environmentVariables).then((travisToken) => {
+        fetchRepository(travisToken, configs.username, configs.projectName).then((repo) => {
+          listEnvironmentVariables(travisToken, repo.id).then((envVarsRetrieved) => {
+            deleteRepository(configs.projectName, configs.username, configs.password).then(() => {
+              // Verify it was initialized
+              const expectedSlug = `${configs.username}/${configs.projectName}`;
+              assert.equal(repo.slug, expectedSlug);
 
-    // Verify it was initialized
-    const expectedSlug = `${configs.username}/${configs.projectName}`;
-    assert.equal(repo.slug, expectedSlug);
+              // Verify the environment variables were properly set
+              for (let i = 0; i < environmentVariables.length; i++) {
+                assert.equal(envVarsRetrieved[i].name, environmentVariables[i].name);
+                const expectedValue = (environmentVariables[i].public) ? environmentVariables[i].value : null;
+                assert.equal(envVarsRetrieved[i].value, expectedValue);
+                assert.equal(envVarsRetrieved[i].public, (environmentVariables[i].public || false));
+              }
 
-    // Verify the environment variables were properly set
-    for (let i = 0; i < environmentVariables.length; i++) {
-      assert.equal(envVarsRetrieved[i].name, environmentVariables[i].name);
-      const expectedValue = (environmentVariables[i].public) ? environmentVariables[i].value : null;
-      assert.equal(envVarsRetrieved[i].value, expectedValue);
-      assert.equal(envVarsRetrieved[i].public, (environmentVariables[i].public || false));
-    }
+              // The test is now complete
+              done();
+            });
+          });
+        });
+      });
+    });
   });
-
 });

--- a/test/integration/github-travis-api-test.js
+++ b/test/integration/github-travis-api-test.js
@@ -119,6 +119,11 @@ describe('GitHub API:', function() {
 
     // Create a token for use in testing
     await createTestToken();
+
+    console.log(`username: ${configs.username}\nprojectName: ${configs.projectName}`);
+    if (!configs.token) {
+      assert.fail('OAuth token not successfully created!');
+    }
   });
 
   after(async () => {


### PR DESCRIPTION
Closes #99 

- Integration tests run only on daily cron job
- Adds caching for the "node_modules" directory. From the TravisCI documentation:
> `npm install` will still run on every build and will update/install any new packages added to your `package.json` file.

Resources:

- https://docs.travis-ci.com/user/languages/javascript-with-nodejs/
- https://docs.travis-ci.com/user/build-stages/
- https://docs.travis-ci.com/user/cron-jobs/