### PR TITLE
Fix 108 110 GitHub

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -130,17 +130,6 @@ export async function initProject(config) {
     }
   }
 
-  if (!config.credentials.github.isTwoFactorAuth) {
-    await deleteGitHubToken(
-      config.credentials.github.url,
-      config.credentials.github.username,
-      config.credentials.github.password
-    );
-  } else {
-    log.warn('Could not delete GitHub token since you are using two factor authentication.' +
-      ' Please visit https://github.com/settings/tokens to manually delete your token.');
-  }
-
   // run npm install on project
   utils.npm.npmInstall(`${config.projectConfigurations.projectName}`);
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -136,8 +136,6 @@ export async function initProject(config) {
       config.credentials.github.username,
       config.credentials.github.password
     );
-
-    log.info('Successfully deleted github token');
   } else {
     log.warn('Could not delete GitHub token since you are using two factor authentication.' +
       ' Please visit https://github.com/settings/tokens to manually delete your token.');
@@ -179,7 +177,6 @@ async function signInToGithub() {
       );
   }
 
-  log.info('Successfully logged into GitHub!');
   return finalCredentials;
 }
 
@@ -274,12 +271,12 @@ export default async function run(tyr) {
     await initProject(configs);
     log.info('Successfully generated your project!');
   } catch (err) {
+    log.error('Failed to generate your project!', err);
+  } finally {
     await deleteGitHubToken(
       configs.credentials.github.url,
       configs.credentials.github.username,
       configs.credentials.github.password
     );
-
-    log.error('Failed to generate your project!');
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -90,16 +90,16 @@ export async function initProject(config) {
 
   const environmentVariables = [];
   // create Dockerfile and .dockerignore
-  if (config.tooling.containerization === constants.docker.name) {
-    environmentVariables.push({
-      name: 'DOCKER_USERNAME',
-      value: config.credentials.docker.username
-    });
-    environmentVariables.push({
-      name: 'DOCKER_PASSWORD',
-      value: config.credentials.docker.password
-    });
-  }
+  // if (config.tooling.containerization === constants.docker.name) {
+  //   environmentVariables.push({
+  //     name: 'DOCKER_USERNAME',
+  //     value: config.credentials.docker.username
+  //   });
+  //   environmentVariables.push({
+  //     name: 'DOCKER_PASSWORD',
+  //     value: config.credentials.docker.password
+  //   });
+  // }
 
   if (config.tooling.deployment === constants.heroku.name) {
     environmentVariables.push({
@@ -250,9 +250,8 @@ export default async function run(tyr) {
   if (tyr.logfile) {
     enableLogFile(tyr.logfile);
   }
-
+  let configs = {};
   try {
-    let configs = {};
     log.verbose('run');
     log.info(figlet.textSync(constants.tyr.name, { horizontalLayout: 'full' }));
 
@@ -275,6 +274,12 @@ export default async function run(tyr) {
     await initProject(configs);
     log.info('Successfully generated your project!');
   } catch (err) {
+    await deleteGitHubToken(
+      configs.credentials.github.url,
+      configs.credentials.github.username,
+      configs.credentials.github.password
+    );
+
     log.error('Failed to generate your project!');
   }
 }

--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -45,7 +45,7 @@ export async function deleteGitHubToken(githubUrl, username, password) {
     return new Promise((resolve, reject) => {
       superagent
         .delete(githubUrl)
-        .set({Authorization: authorizationUtil.basicAuthorization(username, password)})
+        .set({ Authorization: authorizationUtil.basicAuthorization(username, password) })
         .end((err) => {
           if (err) {
             if (err.response.status !== 404) {

--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -105,8 +105,6 @@ export function requestGitHubToken(username, password, otpCode, note = 'hammer-i
       if (err) {
         reject(filterErrorResponse(err));
       } else {
-        // do something when app is closing
-
         resolve({ token: res.body.token, url: res.body.url });
       }
     });

--- a/src/clients/github.js
+++ b/src/clients/github.js
@@ -49,8 +49,9 @@ export async function deleteGitHubToken(githubUrl, username, password) {
         .end((err) => {
           if (err) {
             if (err.response.status !== 404) {
-              console.log('Already deleted');
               reject(filterErrorResponse(err));
+            } else {
+              resolve();
             }
           } else {
             log.info('Successfully deleted github token');

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -101,8 +101,7 @@ export async function signIntoGithub(username, password) {
       // the user's request could not be authenticated, so return false.
       return false;
     } else if (err.status === 422) {
-      log.error('A github token has already been created.  Please go to GitHub and delete the hammer-to token' +
-        ' under Settings -> Developer Settings -> Personal Access Tokens -> Delete hammer-io token.');
+      log.error('A github token has already been created.  Please go to https://github.com/settings/tokens and delete hammer-io token.');
     } else {
       // something bad has happened if we get here.
       log.error('failed to sign in to github', err);

--- a/src/utils/git.js
+++ b/src/utils/git.js
@@ -72,6 +72,7 @@ export async function signIntoGithub(username, password) {
     credentials.token = token.token;
     credentials.url = token.url;
     credentials.isTwoFactorAuth = false;
+    log.info('Successfully logged into GitHub!');
     return credentials;
   } catch (err) {
     // if the above call was not successful, we will end up here...
@@ -91,6 +92,7 @@ export async function signIntoGithub(username, password) {
         credentials.token = token.token;
         credentials.url = token.url;
         credentials.isTwoFactorAuth = true;
+        log.info('Successfully logged into GitHub!');
         return credentials;
       } catch (error) {
         log.error('failed to sign into github', error);
@@ -98,23 +100,32 @@ export async function signIntoGithub(username, password) {
     } else if (err.status === 401) {
       // the user's request could not be authenticated, so return false.
       return false;
+    } else if (err.status === 422) {
+      log.error('A github token has already been created.  Please go to GitHub and delete the hammer-to token' +
+        ' under Settings -> Developer Settings -> Personal Access Tokens -> Delete hammer-io token.');
     } else {
       // something bad has happened if we get here.
       log.error('failed to sign in to github', err);
     }
   }
-
   return credentials;
 }
 
 /**
  * Setups up a GitHub repo, by requesting a GitHub token, creating a .gitignore,
- * and initializing the local and remote repository
+ * and initializing the local and remote repository. If github cannot be setup,
+ * a message will be printed to the user alerting them the github repo was not
+ * setup.
  *
  * @param projectName
  * @param projectDescription
- * @param username
- * @param password
+ * @param credentials
+ *  {
+ *      username: 'username',
+ *      password: 'password',
+ *      token: 'token',
+ *      isTwoFactorAuth: false
+ *  }
  */
 export async function setupGitHub(projectName, projectDescription, credentials) {
   log.verbose('setting up github', credentials.username);
@@ -122,6 +133,7 @@ export async function setupGitHub(projectName, projectDescription, credentials) 
   try {
     await createGitHubRepository(projectName, projectDescription, credentials.token);
     await initAddCommitAndPush(credentials.username, projectName, credentials.isTwoFactorAuth);
+    log.info('Successfully setup GitHub');
   } catch (err) {
     log.error('failed to set up github', err);
   }

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -5,9 +5,10 @@ import {
 } from '../dist/utils/file';
 
 // Tests need to import transpiled files that will be located in dist/ rather than src/
-import { initProject, isUserFinishedWithPrereqs } from '../dist/cli'
+import { isUserFinishedWithPrereqs } from '../dist/cli'
 import constants from '../dist/constants/constants';
 import { generateProjectFiles } from '../dist/cli';
+import {deleteGitHubToken} from '../src/clients/github';
 
 const configs = {
   projectConfigurations: {


### PR DESCRIPTION
closes #108 
closes #110 

Modifies delete GitHub token so it doesn't throw an exception if there is no token with that url, and if the url doesn't exist, it doesn't try to delete it.  Also, only prints that is was successful upon success.  
Added something to print out to the user if they need to delete the GitHub token if it already exists.