### PR TITLE
fixes issue where an UnhandledPromiseRejectionWarning would be thrown…

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -315,10 +315,18 @@ export default async function run(tyr) {
   } catch (err) {
     log.error('Failed to generate your project!', err);
   } finally {
-    await deleteGitHubToken(
-      configs.credentials.github.url,
-      configs.credentials.github.username,
-      configs.credentials.github.password
-    );
+    if (typeof configs.credentials.github !== 'undefined') {
+      try {
+        await
+        deleteGitHubToken(
+          configs.credentials.github.url,
+          configs.credentials.github.username,
+          configs.credentials.github.password
+        );
+      } catch (error) {
+        log.error('Failed to delete github token. Go to https://github.com/settings/tokens and' +
+          ' make sure the hammer-io token is deleted.', error);
+      }
+    }
   }
 }


### PR DESCRIPTION
fixes #140 

* fixes an issue where an unhandled promise rejection warning would be thrown if the user did not use github
* the issue was that the finally block, deleteGitHubToken was looking for credentials, but they were not necessarily there since they user did not have to enter them. 
* added a check to make sure they were there before calling the function