### PR TITLE
generate test.js underneath a test directory

### DIFF
--- a/src/services/mocha-service.js
+++ b/src/services/mocha-service.js
@@ -12,7 +12,8 @@ const log = getActiveLogger();
  */
 export async function generateMochaFiles(projectName) {
   log.verbose('Mocha Service - generateMochaFiles()');
-  const path = `${projectName}/test.js`;
+  fs.mkdirSync(`${projectName}/test`);
+  const path = `${projectName}/test/test.js`;
   const content = file.loadTemplate('./../../templates/mocha/test.js');
 
   // add mocha as a dev dependency to the package.json

--- a/test/mocha-service.test.js
+++ b/test/mocha-service.test.js
@@ -39,8 +39,8 @@ describe('Mocha Service Test', () => {
 
       await generateMochaFiles('test-mocha');
 
-      assert.equal(fs.existsSync('test-mocha/test.js'), true);
-      assert.equal(eol.auto(fs.readFileSync('test-mocha/test.js', 'utf-8')), eol.auto(expectedMochaContents));
+      assert.equal(fs.existsSync('test-mocha/test/test.js'), true);
+      assert.equal(eol.auto(fs.readFileSync('test-mocha/test/test.js', 'utf-8')), eol.auto(expectedMochaContents));
     });
 
     it('should add mocha as a dev dependency and update the test script', async () => {


### PR DESCRIPTION
closes #141 

* generates test.js in the test/ directory
* updates relevant tests. 