### PR TITLE
add precommit hook for tests and lints

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "prepublishOnly": "npm run build",
     "integrationTests": "TYR_TEST_LEVEL=verbose npm test test/integration"
   },
+  "pre-commit": [
+    "lint"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/hammer-io/tyr.git"
@@ -61,6 +64,7 @@
     "mocha": "3.5.3",
     "mock-stdin": "^0.3.1",
     "nyc": "^11.2.1",
+    "pre-commit": "^1.2.2",
     "sinon": "^4.1.3"
   },
   "engines": {


### PR DESCRIPTION
closes #159 

* Adds a precommit hook for linting and, by default, tests. 